### PR TITLE
Multiple arguments to print: change ", " separator to space

### DIFF
--- a/byu_pytest_utils/io_checker.py
+++ b/byu_pytest_utils/io_checker.py
@@ -49,7 +49,7 @@ class IOChecker:
     def _print(self, *values, **kwargs):
         sep = kwargs.get('sep', ', ')
         end = kwargs.get('end', '\n')
-        res = sep.join(str(t) for t in values) + end
+        res = " ".join(str(t) for t in values) + end
         self.observed_output += res
         self._assert_output()
         if self.echo_output:


### PR DESCRIPTION
The problem is that students will give multiple parameters to print, such as:
`print(bullet, item)`
which normally outputs 
`- tomato`
yet pytest compares
`-, tomato`