### PR TITLE
record a test's module when storing group stats

### DIFF
--- a/byu_pytest_utils/dialog.py
+++ b/byu_pytest_utils/dialog.py
@@ -32,6 +32,7 @@ def _make_group_stats_decorator(group_stats):
 
         new_func._group_stats = group_stats
         new_func.__name__ = func.__name__
+        new_func.__module__ = func.__module__
         return new_func
 
     return decorator
@@ -325,7 +326,8 @@ class DialogChecker:
                     with open(output_file) as output:
                         group_stats = self._score_output(output.read())
                 else:
-                    group_stats = self._score_output(f"File not found: {output_file}. Did you write it?")
+                    group_stats = self._score_output(
+                        f"File not found: {output_file}. Did you write it?")
             else:
                 group_stats = self._score_output(self.observed_output)
 
@@ -392,7 +394,8 @@ class DialogChecker:
                     with open(output_file) as file:
                         group_stats = self._score_output(file.read())
                 else:
-                    group_stats = self._score_output(f'File not found: {output_file}. Did you write it?')
+                    group_stats = self._score_output(
+                        f'File not found: {output_file}. Did you write it?')
             else:
                 group_stats = self._score_output(self.observed_output)
 

--- a/byu_pytest_utils/pytest_plugin.py
+++ b/byu_pytest_utils/pytest_plugin.py
@@ -39,7 +39,7 @@ def pytest_generate_tests(metafunc):
         for group_name, stats in group_stats.items():
             stats['max_score'] *= getattr(metafunc.function, 'max_score', 0)
             stats['score'] *= getattr(metafunc.function, 'max_score', 0)
-            test_name = f'{metafunc.function.__name__}[{group_name}]'
+            test_name = f'{metafunc.function.__module__}.py::{metafunc.function.__name__}[{group_name}]'
             test_group_stats[test_name] = stats
 
         metafunc.parametrize('group_name', group_stats.keys())
@@ -55,7 +55,8 @@ def pytest_runtest_makereport(item):
     if item._obj not in metadata:
         metadata[item._obj] = {}
     metadata[item._obj]['max_score'] = getattr(item._obj, 'max_score', 0)
-    metadata[item._obj]['visibility'] = getattr(item._obj, 'visibility', 'visible')
+    metadata[item._obj]['visibility'] = getattr(
+        item._obj, 'visibility', 'visible')
     x._result.metadata_key = item._obj
 
 
@@ -81,7 +82,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus):
 
     for s in all_tests:
         output = s.capstdout + '\n' + s.capstderr
-        group_stats = test_group_stats[s.head_line]
+        group_stats = test_group_stats[s.nodeid]
 
         max_score = group_stats['max_score']
         score = group_stats.get('score', max_score if s.passed else 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "byu_pytest_utils"
-version = "0.7.0"
+version = "0.7.1"
 description = "A few utilities for pytest to help with integration into gradescope"
 authors = ["Gordon Bean <gbean@cs.byu.edu>", "Daniel Zappala <daniel.zappala@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
The pytest plugin (`pytest_plugin.py`) has a global variable, `test_group_stats`, which collects the group stats from each test ran. It is populated in `pytest_generate_tests` and consumed in `pytest_terminal_summary` to create the `results.json` file that Gradescope needs. Previously, the key into `test_group_stats` was the name of the test and graded region formatted into a string. However, this caused an issue when two Python files containing tests for pytest to run had a test by the same name. This meant that the later test trampled on the group stats of the earlier test, even though the two tests were completely separate and independent of each other. To remedy this problem, I added the test file's name into the formatted string that's used as a key into `pytest_terminal_summary`.