### PR TITLE
fix bug with non-group-stats tests

### DIFF
--- a/byu_pytest_utils/pytest_plugin.py
+++ b/byu_pytest_utils/pytest_plugin.py
@@ -44,7 +44,8 @@ def pytest_generate_tests(metafunc):
 
         metafunc.parametrize('group_name', group_stats.keys())
     else:
-        test_group_stats[metafunc.definition.name] = {
+        test_name = f'{metafunc.function.__module__}.py::{metafunc.function.__name__}'
+        test_group_stats[test_name] = {
             'max_score': getattr(metafunc.function, 'max_score', 0)
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "byu_pytest_utils"
-version = "0.7.1"
+version = "0.7.2"
 description = "A few utilities for pytest to help with integration into gradescope"
 authors = ["Gordon Bean <gbean@cs.byu.edu>", "Daniel Zappala <daniel.zappala@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
When I made the original bug fix, I forgot to account for tests that didn't use the dialog framework. I've fixed that now 😬