### PR TITLE
Catch infinite loops

### DIFF
--- a/byu_pytest_utils/dialog.py
+++ b/byu_pytest_utils/dialog.py
@@ -326,13 +326,20 @@ class DialogChecker:
 
         # Run script as __main__
         try:
+            finishes_on_time = False
             proc = multiprocessing.Process(target=runpy.run_path, args=(script_name, _globals, module))
             proc.start()
             # Kill the script if it takes too long
             timer = threading.Timer(6, proc.terminate)
             timer.start()
             proc.join()
-            timer.cancel()
+            if timer.is_alive():
+                finishes_on_time = True
+                timer.cancel()
+            if not finishes_on_time:
+                raise Exception("Error: File did not finish. Check your while and for loops for infinite loops.")
+
+            
 
             if output_file is not None:
                 if os.path.exists(output_file):

--- a/byu_pytest_utils/dialog.py
+++ b/byu_pytest_utils/dialog.py
@@ -140,6 +140,7 @@ def _exec_read_stdout_with_timeout(p, timeout=_EXEC_DEFAULT_MAX_WAITTIME_BEFORE_
             yield queue.get_nowait()
 
 
+
 class DialogChecker:
     DEFAULT_GROUP = '.'
     DEFAULT_GROUP_NAME = 'everything-else'
@@ -309,23 +310,26 @@ class DialogChecker:
         res = sep.join(str(t) for t in values) + end
         self._consume_output(res)
 
+
     def run_script(self, script_name, *args, output_file=None, module='__main__'):
+        global myprint, myinput
+        myprint = self._py_print
+        myinput = self._py_input
         # Intercept input, print, and sys.argv
         sys.argv = [script_name, *(str(a) for a in args)]
         _globals = {
             # 'input': self._py_input,
-            # 'print': self._py_print,
-            # 'sys.argv': sys.argv,
+            'print': myprint,
+            'sys.argv': sys.argv.copy(),
             # 'sys': sys
         }
-
 
         # Run script as __main__
         try:
             proc = multiprocessing.Process(target=runpy.run_path, args=(script_name, _globals, module))
             proc.start()
             # Kill the script if it takes too long
-            timer = threading.Timer(4, proc.terminate)
+            timer = threading.Timer(6, proc.terminate)
             timer.start()
             proc.join()
             timer.cancel()

--- a/tests/script_infinite_loop_fails.py
+++ b/tests/script_infinite_loop_fails.py
@@ -1,0 +1,11 @@
+import sys
+
+
+print("Not main")
+
+if __name__ == '__main__':
+    print("My args:", sys.argv)
+    list = [1, 2, 3]
+    for item in list:
+        print(item)
+        list.append(item + 3)

--- a/tests/script_infinite_loop_fails.py
+++ b/tests/script_infinite_loop_fails.py
@@ -1,8 +1,5 @@
 import sys
 
-
-print("Not main")
-
 if __name__ == '__main__':
     print("My args:", sys.argv)
     list = [1, 2, 3]

--- a/tests/test_dialog_framework.py
+++ b/tests/test_dialog_framework.py
@@ -27,6 +27,7 @@ def test_dialog_should_fail():
 def test_infinite_loop_should_fail():
     """
     The test should fail due to an infinite loop
+    There should be an error: "File did not finish. Check your while and for loops for infinite loops."
     """
 
 @dialog(

--- a/tests/test_dialog_framework.py
+++ b/tests/test_dialog_framework.py
@@ -24,7 +24,7 @@ def test_dialog_should_fail():
     "script_infinite_loop_fails.py", 'woot', 7, 'foobar'
 )
 @max_score(10)
-def test_infinite_loop_fail():
+def test_infinite_loop_should_fail():
     """
     The test should fail due to an infinite loop
     """

--- a/tests/test_dialog_framework.py
+++ b/tests/test_dialog_framework.py
@@ -20,6 +20,16 @@ def test_dialog_should_fail():
     """
 
 @dialog(
+    "dialogs/test_dialog_should_pass.txt",
+    "script_infinite_loop_fails.py", 'woot', 7, 'foobar'
+)
+@max_score(10)
+def test_infinite_loop_fail():
+    """
+    The test should fail due to an infinite loop
+    """
+
+@dialog(
     "dialogs/test_dialog_expects_more_input.txt",
     "script_for_dialog_passes.py", 'woot'
 )


### PR DESCRIPTION
This draft works, but is not ideal.
The goal is to throw an exception when student code is in an infinite loop. 
The way this is detected is whether the student's code takes more than six seconds to run.
This is in the dialog checker, so it's not run for the bit units.

The hard problem is creating a killable process that modifies local variables. 

`runpy.run_path(script_name, _globals, module)` can modify local variables through its global argument.

`multiprocessing.Process()` creates a killable process, but its pickling requirement makes modification difficult.

My current solution runs the process once using multiprocessing.Process() to check if the code contains an infinite loop. If it does, we stop testing the student's code and throw an exception. If it does not, we run the code again using `runpy.run_path` and process their output as normal.