### PR TITLE
Migrate PyPI publishing to OIDC trusted publishers

### DIFF
--- a/.github/workflows/poetry_publish.yaml
+++ b/.github/workflows/poetry_publish.yaml
@@ -2,8 +2,9 @@ name: byu_pytest_utils Publish
 
 on:
   workflow_dispatch:
-  push:
-    branches: [master]
+  # TODO: Re-enable after OIDC trusted publisher is configured on pypi.org
+  # push:
+  #   branches: [master]
 
 permissions:
   id-token: write

--- a/.github/workflows/poetry_publish.yaml
+++ b/.github/workflows/poetry_publish.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
-    types: [merged]
+
+permissions:
+  id-token: write
 
 jobs:
   byu_pytest_utils_publish:
@@ -14,8 +14,5 @@ jobs:
     with:
       pypi_package: "byu_pytest_utils"
     secrets:
-      pypi_user: ${{ secrets.PYPI_USER }}
-      pypi_password: ${{ secrets.PYPI_PASSWORD }}
       discord_webhook_url: ${{ secrets.GHA_DISCORD_WEBHOOK }}
       discord_role: ${{ secrets.CICD_NOTIFY_DISCORD_ROLE }}
-

--- a/.github/workflows/poetry_publish.yaml
+++ b/.github/workflows/poetry_publish.yaml
@@ -2,9 +2,8 @@ name: byu_pytest_utils Publish
 
 on:
   workflow_dispatch:
-  # TODO: Re-enable after OIDC trusted publisher is configured on pypi.org
-  # push:
-  #   branches: [master]
+  push:
+    branches: [master]
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
Migrate from `pypi_user`/`pypi_password` secrets to PyPI OIDC trusted publishers, as required by the updated `poetry_publish.yaml` reusable workflow in [BYU-CS-Course-Ops/utils#7](https://github.com/BYU-CS-Course-Ops/utils/pull/7).

## Changes
- Added `permissions: id-token: write` at workflow level (required for OIDC token issuance)
- Removed `pypi_user` and `pypi_password` from secrets block
- Removed stale `pull_request` trigger (the `push` trigger already covers merged PRs)

## Before merging
1. **Configure a trusted publisher on [pypi.org](https://pypi.org/project/byu-pytest-utils/)**:
   - Go to byu-pytest-utils package → Manage → Publishing → Add GitHub Actions publisher
   - **Owner:** `BYU-CS-Course-Ops`
   - **Repository:** `byu_pytest_utils`
   - **Workflow name:** `poetry_publish.yaml`
   - **Environment:** leave blank
2. Merge [BYU-CS-Course-Ops/utils#7](https://github.com/BYU-CS-Course-Ops/utils/pull/7) first — this PR depends on the updated reusable workflow

## After merging
- The `PYPI_USER` and `PYPI_PASSWORD` repository secrets can be removed from GitHub Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)